### PR TITLE
Update DlangUI and fix changes.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -13,5 +13,5 @@ configuration "gtk" {
 
 configuration "dlangui" {
     versions "dlangui"
-    dependency "dlangui" version="~>0.9.120"
+    dependency "dlangui" version="~>0.9.177"
 }

--- a/source/plot2d/backend/dlangui.d
+++ b/source/plot2d/backend/dlangui.d
@@ -180,13 +180,13 @@ override:
         g.blackBoxY = 15;
         g.originX = 0;
         g.originY = 0;
-        g.width = 10;
+        g.widthPixels = 10;
         auto hh = 15;
-        g.glyph.length = g.width * hh;
-        foreach (i; 0..hh) foreach (j; 0..g.width)
+        g.glyph.length = g.widthPixels * hh;
+        foreach (i; 0..hh) foreach (j; 0..g.widthPixels)
         {
-            if (i == j || g.width - i == j)
-                g.glyph[i*g.width + j] = 1;
+            if (i == j || g.widthPixels - i == j)
+                g.glyph[i*g.widthPixels + j] = 1;
         }
         foreach (c; str)
             buf.drawGlyph(cast(int)p.x, cast(int)p.y, &g,


### PR DESCRIPTION
DlangUI 0.9.151 changed the name of the Glyph's "width" property to "widthPixels" and added a "widthScaled" property. This updates DlangUI to the most recent version (0.9.177) and fixes the name.